### PR TITLE
Update gh page links

### DIFF
--- a/_posts/2016-01-25-Utrecht.md
+++ b/_posts/2016-01-25-Utrecht.md
@@ -2,4 +2,4 @@
 layout: post
 title:  Essential skills workshop, Jan 2016, Utrecht
 ---
-Our first Essential skills workshop from 2016 took place in Utrecht. For more information visit the workshop [repository](https://github.com/escience-academy/essential-skills-25-01-2016-Utrecht) and [page](http://mkuzak.github.io/2016-01-25-Utrecht/).
+Our first Essential skills workshop from 2016 took place in Utrecht. For more information visit the workshop [repository](https://github.com/esciencecenter-digital-skills/essential-skills-25-01-2016-Utrecht) and [page](http://mkuzak.github.io/2016-01-25-Utrecht/).

--- a/_posts/2017-09-08-Utrecht.md
+++ b/_posts/2017-09-08-Utrecht.md
@@ -3,6 +3,6 @@ layout: post
 title: Software Carpentry, Sep 2017, Utrecht
 ---
 Our September 2017  round of essential skills workshops covered 3 lessons over 3 days:
-[Version Control and Collaboration with Git and GitHub](https://escience-academy.github.io/2017-09-06-git-github/),
-[Unix Shell and Task Automation](https://escience-academy.github.io/2017-09-07-shell-automation/) and
-[Introduction to Scientific Data Analysis in Python](https://escience-academy.github.io/2017-09-08-python-intro/).
+[Version Control and Collaboration with Git and GitHub](https://esciencecenter-digital-skills.github.io/2017-09-06-git-github/),
+[Unix Shell and Task Automation](https://esciencecenter-digital-skills.github.io/2017-09-07-shell-automation/) and
+[Introduction to Scientific Data Analysis in Python](https://esciencecenter-digital-skills.github.io/2017-09-08-python-intro/).

--- a/_posts/2017-11-06-Utrecht.md
+++ b/_posts/2017-11-06-Utrecht.md
@@ -2,4 +2,4 @@
 layout: post
 title: Integrating Data management into Compute Workflows, Nov 2017, Utrecht
 ---
-Our November 2017 round of essential skills workshops focused on [Integrating Data management into Compute Workflows](https://escience-academy.github.io/2017-11-06-research-data-handling/) with big thanks to SURFsara.
+Our November 2017 round of essential skills workshops focused on [Integrating Data management into Compute Workflows](https://esciencecenter-digital-skills.github.io/2017-11-06-research-data-handling/) with big thanks to SURFsara.

--- a/_posts/2018-01-23-Wageningen.md
+++ b/_posts/2018-01-23-Wageningen.md
@@ -3,4 +3,4 @@ layout: post
 title: Essential skills workshop, Jan 2018, Wageningen
 ---
 A special round of essential skills workshops hosted by Wageningen University focused on
-[Github and Python](https://escience-academy.github.io/2018-01-23-wageningen/) and [Computing stochastic model with tipping points](https://github.com/jhidding/stability).
+[Github and Python](https://esciencecenter-digital-skills.github.io/2018-01-23-wageningen/) and [Computing stochastic model with tipping points](https://github.com/jhidding/stability).

--- a/_posts/2018-04-20-Amsterdam.md
+++ b/_posts/2018-04-20-Amsterdam.md
@@ -3,5 +3,5 @@ layout: post
 title: Essential skills workshop, Apr 2018, Amsterdam
 ---
 Our April 2018 round of essential skills workshops covered 2 lessons over 2 days:
-[Introduction to Scientific Data Analysis in Python](https://escience-academy.github.io/2018-04-20-Amsterdam/) and
-[Version Control and Collaboration with Git and GitHub](https://escience-academy.github.io/2018-04-19-Amsterdam/).
+[Introduction to Scientific Data Analysis in Python](https://esciencecenter-digital-skills.github.io/2018-04-20-Amsterdam/) and
+[Version Control and Collaboration with Git and GitHub](https://esciencecenter-digital-skills.github.io/2018-04-19-Amsterdam/).

--- a/_posts/2018-06-25-Exeter.md
+++ b/_posts/2018-06-25-Exeter.md
@@ -3,7 +3,7 @@ layout: post
 title: Git, NetCDF adn cartopy, June 2018, CDT summer school
 ---
 We were invited to organize the lab sessions during the CDT summer school at the
-Met Office in Exeter, UK. The [lab sessions](https://github.com/escience-academy/2018-06-25-UK-MetOffice-Summer-school)
+Met Office in Exeter, UK. The [lab sessions](https://github.com/esciencecenter-digital-skills/2018-06-25-UK-MetOffice-Summer-school)
 covered a range of topics such as git, NetCDF and cartopy. Students also had
 the time to work on their own mini-project, which they presented at the end of
 the week.

--- a/_posts/2018-08-29-BQMinded.md
+++ b/_posts/2018-08-29-BQMinded.md
@@ -2,6 +2,6 @@
 layout: post
 title: Software Carpentry, Aug 208, BQ-Minded summer school
 ---
-We were invited to participate in the BQ-Minded summer school, in Antwerp, Belgium. [This workshop](https://escience-academy.github.io/2018-08-29-BQMinded/) covered Unix Shell & Task Automation and Introduction to Git/GitHub from the standard Software Carpentry curriculum, plus a custom session on Scientific data analysis with Python. In this lesson we focused on model fitting and image processing.
+We were invited to participate in the BQ-Minded summer school, in Antwerp, Belgium. [This workshop](https://esciencecenter-digital-skills.github.io/2018-08-29-BQMinded/) covered Unix Shell & Task Automation and Introduction to Git/GitHub from the standard Software Carpentry curriculum, plus a custom session on Scientific data analysis with Python. In this lesson we focused on model fitting and image processing.
 
 We also wrote [a blog](https://blog.esciencecenter.nl/want-to-organize-a-workshop-on-image-processing-5727d2347de2) post about this workshop and poster it over at [the carpentries blog](https://carpentries.org/blog/2018/09/image_processing_resources/).

--- a/_posts/2018-09-18-Utrecht.md
+++ b/_posts/2018-09-18-Utrecht.md
@@ -4,10 +4,10 @@ title: Good practices in research software, September 2018 - Utrecht
 ---
 Our September 2018 round of essential skills workshops covered was quite special:
 
-We focused on [Good practices in research software ](https://escience-academy.github.io/2018-09-18-Utrecht/)
+We focused on [Good practices in research software ](https://esciencecenter-digital-skills.github.io/2018-09-18-Utrecht/)
 using newly developed material from [the carpentries](https://carpentries.org/) (which we helped developing).
 And with the help of Jeroen Engelberts from [SURFsara](https://www.surf.nl) we focused on
-[High Performance Computing for Research ](https://escience-academy.github.io/2018-09-19-Utrecht/).
+[High Performance Computing for Research ](https://esciencecenter-digital-skills.github.io/2018-09-19-Utrecht/).
 
 It was also Jeroen's last workshop working with SURF -- all the best to him
 in his new path, and I hope we will be able to work together in the future.

--- a/_posts/2019-10-08-Amsterdam.md
+++ b/_posts/2019-10-08-Amsterdam.md
@@ -3,4 +3,4 @@ layout: post
 title: Parallel programming in Python workshop, Oct 2019
 ---
 
-We had a full-day [workshop on doing parallel programming in Python](https://escience-academy.github.io/2019-10-08-Amsterdam/). The workshop was a great success and we will repeat it in the future.
+We had a full-day [workshop on doing parallel programming in Python](https://esciencecenter-digital-skills.github.io/2019-10-08-Amsterdam/). The workshop was a great success and we will repeat it in the future.

--- a/_posts/2019-10-10-NSO.md
+++ b/_posts/2019-10-10-NSO.md
@@ -2,4 +2,4 @@
 layout: post
 title: Data Science Toolbox, Oct 2019 - NSO
 ---
-We had a workshop at the Netherlands Space Office (NSO) Earth Observation, Science & Society Symposium. The focus of the workshop was on [data science tooling](https://github.com/escience-academy/2019-10-10-NSO-Symposium), and we showed participants how to work with NetCDF data using Iris.
+We had a workshop at the Netherlands Space Office (NSO) Earth Observation, Science & Society Symposium. The focus of the workshop was on [data science tooling](https://github.com/esciencecenter-digital-skills/2019-10-10-NSO-Symposium), and we showed participants how to work with NetCDF data using Iris.

--- a/_posts/2019-10-22-MARIN.md
+++ b/_posts/2019-10-22-MARIN.md
@@ -2,4 +2,4 @@
 layout: post
 title: Software Carpentry and Parallel Programming, Oct 2019, MARIN
 ---
-We had a workshop at the Maritime Research Institute Netherlands ([MARIN](https://www.marin.nl)). The focus of the workshop was on using [Version Control with Git](https://swcarpentry.github.io/git-novice/) and [Plotting and Programming in Python](https://swcarpentry.github.io/python-novice-gapminder/). The second part of the workshop used the materials from the [Parallel programming in Python workshop](https://escience-academy.github.io/2019/10/08/Amsterdam.html) earlier this month.
+We had a workshop at the Maritime Research Institute Netherlands ([MARIN](https://www.marin.nl)). The focus of the workshop was on using [Version Control with Git](https://swcarpentry.github.io/git-novice/) and [Plotting and Programming in Python](https://swcarpentry.github.io/python-novice-gapminder/). The second part of the workshop used the materials from the [Parallel programming in Python workshop](https://esciencecenter-digital-skills.github.io/2019/10/08/Amsterdam.html) earlier this month.

--- a/_posts/2020-02-11-ROR-Utrecht.md
+++ b/_posts/2020-02-11-ROR-Utrecht.md
@@ -2,4 +2,4 @@
 layout: post
 title: Getting started with Reproducible and Open Research, Feb 2020 - Utrecht
 ---
-[Getting started with Reproducible and Open Research](https://escience-academy.github.io/2020-02-11-Reproducible-and-Open-Research/)
+[Getting started with Reproducible and Open Research](https://esciencecenter-digital-skills.github.io/2020-02-11-Reproducible-and-Open-Research/)

--- a/_posts/2020-04-14-SWC-online.md
+++ b/_posts/2020-04-14-SWC-online.md
@@ -2,4 +2,4 @@
 layout: post
 title: Software Carpentry Online Workshop, 14-17 April, 2020
 ---
-[Software Carpentry Online Workshop, 14-17 April, 2020](https://escience-academy.github.io/2020-04-14-SWC-online/)
+[Software Carpentry Online Workshop, 14-17 April, 2020](https://esciencecenter-digital-skills.github.io/2020-04-14-SWC-online/)

--- a/_posts/2020-05-27-fair-software-cmbi.md
+++ b/_posts/2020-05-27-fair-software-cmbi.md
@@ -2,4 +2,4 @@
 layout: post
 title: Fair Software Online Workshop, May 27, 2020, CMBI Radboud UMC
 ---
-[Fair Software Online Workshop, May 27, 2020, CMBI Radboud UMC](https://escience-academy.github.io/2020-05-27-fair-software-cmbi/)
+[Fair Software Online Workshop, May 27, 2020, CMBI Radboud UMC](https://esciencecenter-digital-skills.github.io/2020-05-27-fair-software-cmbi/)

--- a/_posts/2020-07-30-cchome-fair-software.md
+++ b/_posts/2020-07-30-cchome-fair-software.md
@@ -2,4 +2,4 @@
 layout: post
 title: Fair Software Online Workshop, July 30, 2020, CarpentryCon @ Home
 ---
-[FAIR Software Online Workshop, July 30, 2020](https://escience-academy.github.io/2020-07-30-cchome-fair-software/)
+[FAIR Software Online Workshop, July 30, 2020](https://esciencecenter-digital-skills.github.io/2020-07-30-cchome-fair-software/)

--- a/_posts/2020-09-08-4TU-FAIR-software.md
+++ b/_posts/2020-09-08-4TU-FAIR-software.md
@@ -2,4 +2,4 @@
 layout: post
 title: Fair Software Online Workshop, September 8, 2020, 4TU Online
 ---
-[FAIR Software Online Workshop, September 8, 2020](https://escience-academy.github.io/2020-09-08-4tu-fair-software/)
+[FAIR Software Online Workshop, September 8, 2020](https://esciencecenter-digital-skills.github.io/2020-09-08-4tu-fair-software/)

--- a/_posts/2020-09-16-PBL-Python.md
+++ b/_posts/2020-09-16-PBL-Python.md
@@ -3,4 +3,4 @@ layout: post
 title: Python Workshop, September 16, 23, 30, 2020, Online, PBL
 ---
 [Python Workshop, September 16, 23, 30, 2020, PBL Netherlands Environmental
-Assessment Agency](https://escience-academy.github.io/2020-09-16-PBL/)
+Assessment Agency](https://esciencecenter-digital-skills.github.io/2020-09-16-PBL/)

--- a/_posts/2020-09-21-SWC-R-gapminder.md
+++ b/_posts/2020-09-21-SWC-R-gapminder.md
@@ -2,4 +2,4 @@
 layout: post
 title: Software Carpentry Workshop with R, September 21-24, 2020, Online
 ---
-[Software Carpentry Workshop with R, September 21-24, 2020](https://escience-academy.github.io/2020-09-21-SWC-Gapminder/)
+[Software Carpentry Workshop with R, September 21-24, 2020](https://esciencecenter-digital-skills.github.io/2020-09-21-SWC-Gapminder/)

--- a/_posts/2020-10-19-DC-Social-Sci.md
+++ b/_posts/2020-10-19-DC-Social-Sci.md
@@ -2,4 +2,4 @@
 layout: post
 title: Data Carpentry Workshop with R, October 19-22, 2020, Online
 ---
-[Data Carpentry Workshop with R, October 19-22, 2020, Online](https://escience-academy.github.io/2020-10-19-Data-Carpentry-with-R/)
+[Data Carpentry Workshop with R, October 19-22, 2020, Online](https://esciencecenter-digital-skills.github.io/2020-10-19-Data-Carpentry-with-R/)

--- a/_posts/2020-11-16-Code-Refinery.md
+++ b/_posts/2020-11-16-Code-Refinery.md
@@ -2,4 +2,4 @@
 layout: post
 title: Code Refinery Workshop, November 16-19, 2020, Online
 ---
-[Code Refinery Workshop, November 16-19, 2020, Online](https://escience-academy.github.io/2020-11-16-code-refinery/)
+[Code Refinery Workshop, November 16-19, 2020, Online](https://esciencecenter-digital-skills.github.io/2020-11-16-code-refinery/)

--- a/_posts/2020-12-07-Parallel-Python.md
+++ b/_posts/2020-12-07-Parallel-Python.md
@@ -2,4 +2,4 @@
 layout: post
 title: Parallel Python  Workshop, December 7-8, 2020, Online
 ---
-[Introduction to Parallel Programming in Python  Workshop, December 7-8, 2020, Online](https://escience-academy.github.io/2020-12-07-parallel-python/)
+[Introduction to Parallel Programming in Python  Workshop, December 7-8, 2020, Online](https://esciencecenter-digital-skills.github.io/2020-12-07-parallel-python/)

--- a/_posts/2021-03-08-Software-Carpentry-Python.md
+++ b/_posts/2021-03-08-Software-Carpentry-Python.md
@@ -2,4 +2,4 @@
 layout: post
 title: Software Carpentry with Python Workshop, March 8-11, 2021, Online
 ---
-[Software Carpentry with Python Workshop, March 8-11, 2021, Online](https://escience-academy.github.io/2021-03-08-swc-nlesc/)
+[Software Carpentry with Python Workshop, March 8-11, 2021, Online](https://esciencecenter-digital-skills.github.io/2021-03-08-swc-nlesc/)

--- a/_posts/2021-03-23-Containers.md
+++ b/_posts/2021-03-23-Containers.md
@@ -2,4 +2,4 @@
 layout: post
 title: Reproducible Computational Environments Using Containers, March 23, 2021, Online
 ---
-[Reproducible Computational Environments Using Containers, March 23, 2021, Online](https://escience-academy.github.io/2021-03-23-containers/)
+[Reproducible Computational Environments Using Containers, March 23, 2021, Online](https://esciencecenter-digital-skills.github.io/2021-03-23-containers/)

--- a/_posts/2021-03-29-Code-Refinery.md
+++ b/_posts/2021-03-29-Code-Refinery.md
@@ -2,4 +2,4 @@
 layout: post
 title: Code Refinery Workshop, March 29 - April 1, 2021, Online
 ---
-[Code Refinery Workshop, March 29 - April 1, 2021, Online.](https://escience-academy.github.io/2021-03-29-code-refine/)
+[Code Refinery Workshop, March 29 - April 1, 2021, Online.](https://esciencecenter-digital-skills.github.io/2021-03-29-code-refine/)

--- a/_posts/2021-04-12-Parallel-Python.md
+++ b/_posts/2021-04-12-Parallel-Python.md
@@ -2,4 +2,4 @@
 layout: post
 title: Parallel Programming in Python, April, 2021, Online
 ---
-[Parallel programming in Python](https://escience-academy.github.io/2021-04-12-parallel-python/)
+[Parallel programming in Python](https://esciencecenter-digital-skills.github.io/2021-04-12-parallel-python/)

--- a/_posts/2021-04-19-Data-Carpentry-Python.md
+++ b/_posts/2021-04-19-Data-Carpentry-Python.md
@@ -3,6 +3,6 @@ layout: post
 title: Data Carpentry with Python Workshop, April 19 - 22 , 2021, Online
 ---
 
-[Data Carpentry with Python Workshop, April 19 - 22 , 2021, Online.](https://escience-academy.github.io/2021-04-19-dc-python-nlesc//)
+[Data Carpentry with Python Workshop, April 19 - 22 , 2021, Online.](https://esciencecenter-digital-skills.github.io/2021-04-19-dc-python-nlesc//)
 
 [Registration page](https://3zpb11r.momice.events/page/854828)

--- a/_posts/2021-05-17-swc-R-nlesc.md
+++ b/_posts/2021-05-17-swc-R-nlesc.md
@@ -3,6 +3,6 @@ layout: post
 title: Software Carpentry with R, May 17-20, 2021, Online
 ---
 
-[Software Carpentry with R Workshop, May 17-20, 2021, Online.](https://escience-academy.github.io/2021-05-17-swc-R-nlesc/)
+[Software Carpentry with R Workshop, May 17-20, 2021, Online.](https://esciencecenter-digital-skills.github.io/2021-05-17-swc-R-nlesc/)
 
 [Registration page](https://2aksjfk.momice.events/page/860397)

--- a/_posts/2021-06-02-GPU Programming.md
+++ b/_posts/2021-06-02-GPU Programming.md
@@ -3,6 +3,6 @@ layout: post
 title: GPU Programming, June 2-3 2021, Online
 ---
 
-[GPU Programming, June 2-3 2021, Online.](https://escience-academy.github.io/2021-06-02-gpu/)
+[GPU Programming, June 2-3 2021, Online.](https://esciencecenter-digital-skills.github.io/2021-06-02-gpu/)
 
 [Registration page](https://www.eventbrite.co.uk/e/gpu-programming-tickets-154829528287)

--- a/_posts/2021-06-14-conda.md
+++ b/_posts/2021-06-14-conda.md
@@ -3,6 +3,6 @@ layout: post
 title: Introduction to programming environments with Conda
 ---
 
-[Introduction to programming environments with Conda, June 14 2021, Online.](https://escience-academy.github.io/2021-06-14-conda/)
+[Introduction to programming environments with Conda, June 14 2021, Online.](https://esciencecenter-digital-skills.github.io/2021-06-14-conda/)
 
 [Registration page](https://www.eventbrite.co.uk/e/introduction-to-programming-environments-with-conda-tickets-157212299219)

--- a/_posts/2021-06-29-Parallel-Python.md
+++ b/_posts/2021-06-29-Parallel-Python.md
@@ -2,4 +2,4 @@
 layout: post
 title: Parallel Programming in Python, June 29-30, 2021, Online
 ---
-[Parallel Programming in Python](https://escience-academy.github.io/2021-06-29-parallel-python/)
+[Parallel Programming in Python](https://esciencecenter-digital-skills.github.io/2021-06-29-parallel-python/)

--- a/_posts/2021-07-05-deep-learning.md
+++ b/_posts/2021-07-05-deep-learning.md
@@ -3,4 +3,4 @@ layout: post
 title: Deep Learning, July 5, 2021, Online
 ---
 
-[Deep Learning, July 5-7 2021, Online.](https://escience-academy.github.io/2021-07-05-deep-learning/)
+[Deep Learning, July 5-7 2021, Online.](https://esciencecenter-digital-skills.github.io/2021-07-05-deep-learning/)


### PR DESCRIPTION
gh page cannot be redirected automatically when changing the organisation name. So this commit changes all "escience-academy.github.io" to "esciencecenter-digital-skills.github.io".